### PR TITLE
ci: run apt-get update before installing libcurl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install system dependencies
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -59,7 +61,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install system dependencies
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"


### PR DESCRIPTION
## Summary
- Runner image ships with a stale apt index; the cached libcurl version periodically gets dropped from the mirror and `apt-get install` then fails with a 404 fetch error (see #11)
- Refresh the index with `apt-get update` before installing in both the `rubocop-test` and `publish` jobs

## Test plan
- [ ] Workflow run on this PR completes the "Install system dependencies" step successfully
